### PR TITLE
update deprecated boost url

### DIFF
--- a/org.sil.FieldWorks.yml
+++ b/org.sil.FieldWorks.yml
@@ -192,7 +192,7 @@ modules:
           - "*"
         sources:
           - type: archive
-            url: https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2
+            url: https://archives.boost.io/release/1.71.0/source/boost_1_71_0.tar.bz2
             sha512: b7937d50c4512cf13cadd0ca829de36cf2cbc6fb788f45b1d4565ad0753e2b206c545125a5862016c2f16016f2e4a6b687928963b466fff17c3e0a4437142c20
       - name: dbus-glib
         # For Gecko.


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
